### PR TITLE
Add `wake-word` command line argument

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -59,6 +59,7 @@ const (
 	RequireApprovalFlag        = "require-approval"
 	SSLCertFileFlag            = "ssl-cert-file"
 	SSLKeyFileFlag             = "ssl-key-file"
+	WakeWordFlag               = "wake-word"
 
 	// Flag defaults.
 	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
@@ -69,6 +70,7 @@ const (
 	DefaultLogLevel         = "info"
 	DefaultPort             = 4141
 	DefaultRepoConfig       = "atlantis.yaml"
+	DefaultWakeWord         = "atlantis"
 )
 
 const redTermStart = "\033[31m"
@@ -169,7 +171,8 @@ var stringFlags = []stringFlag{
 		description: "Optional path to the Atlantis YAML config file contained in each repo that this server should use. " +
 			"This allows different Atlantis servers to point at different configs in the same repo.",
 		defaultValue: DefaultRepoConfig,
-	}, {
+	},
+	{
 		name: RepoWhitelistFlag,
 		description: "Comma separated list of repositories that Atlantis will operate on. " +
 			"The format is {hostname}/{owner}/{repo}, ex. github.com/runatlantis/atlantis. '*' matches any characters until the next comma and can be used for example to whitelist " +
@@ -183,6 +186,12 @@ var stringFlags = []stringFlag{
 	{
 		name:        SSLKeyFileFlag,
 		description: fmt.Sprintf("File containing x509 private key matching --%s.", SSLCertFileFlag),
+	},
+	{
+		name: WakeWordFlag,
+		description: "Wake word for this server to listen to. Default is 'atlantis'. " +
+			"This allows different wake commands (e.g. 'staging' or 'prod') to be used for different stages if more than one server operates on the same repo.",
+		defaultValue: DefaultWakeWord,
 	},
 }
 var boolFlags = []boolFlag{
@@ -388,6 +397,9 @@ func (s *ServerCmd) setDefaults(c *server.UserConfig) {
 	}
 	if c.RepoConfig == "" {
 		c.RepoConfig = DefaultRepoConfig
+	}
+	if c.WakeWord == "" {
+		c.WakeWord = DefaultWakeWord
 	}
 }
 

--- a/server/events/comment_parser_test.go
+++ b/server/events/comment_parser_test.go
@@ -28,6 +28,7 @@ var commentParser = events.CommentParser{
 	GithubToken: "github-token",
 	GitlabUser:  "gitlab-user",
 	GitlabToken: "gitlab-token",
+	WakeWord:    "atlantis",
 }
 
 func TestParse_Ignored(t *testing.T) {
@@ -141,8 +142,8 @@ func TestParse_DidYouMeanAtlantis(t *testing.T) {
 	}
 	for _, c := range comments {
 		r := commentParser.Parse(c, models.Github)
-		Assert(t, r.CommentResponse == events.DidYouMeanAtlantisComment,
-			"For comment %q expected CommentResponse==%q but got %q", c, events.DidYouMeanAtlantisComment, r.CommentResponse)
+		Assert(t, r.CommentResponse == commentParser.GetDidYouMeanWakeWordComment(),
+			"For comment %q expected CommentResponse==%q but got %q", c, commentParser.GetDidYouMeanWakeWordComment(), r.CommentResponse)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -108,6 +108,7 @@ type UserConfig struct {
 	SlackToken      string          `mapstructure:"slack-token"`
 	SSLCertFile     string          `mapstructure:"ssl-cert-file"`
 	SSLKeyFile      string          `mapstructure:"ssl-key-file"`
+	WakeWord        string          `mapstructure:"wake-word"`
 	Webhooks        []WebhookConfig `mapstructure:"webhooks"`
 }
 
@@ -257,6 +258,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GithubToken: userConfig.GithubToken,
 		GitlabUser:  userConfig.GitlabUser,
 		GitlabToken: userConfig.GitlabToken,
+		WakeWord:    userConfig.WakeWord,
 	}
 	defaultTfVersion := terraformClient.Version()
 	commandRunner := &events.DefaultCommandRunner{


### PR DESCRIPTION
## what
* Add `wake-word` command line argument

## why
* Allows different wake commands (e.g. 'staging' or 'prod') to be used for different stages if more than one server operates on the same repo. Default is `atlantis`
