### PR TITLE
Fix destroy command comment

### DIFF
--- a/server/events/project_command_runner.go
+++ b/server/events/project_command_runner.go
@@ -63,7 +63,7 @@ type PlanSuccess struct {
 	RePlanCmd string
 	// ApplyCmd is the command that users should run to apply this plan.
 	ApplyCmd string
-	// ApplyCmd is the command that users should run to apply this plan.
+	// DestroyCmd is the command that users should run to destroy this plan.
 	DestroyCmd string
 }
 
@@ -183,6 +183,7 @@ func (p *DefaultProjectCommandRunner) doPlan(ctx models.ProjectCommandContext) (
 		TerraformOutput: strings.Join(outputs, "\n"),
 		RePlanCmd:       ctx.RePlanCmd,
 		ApplyCmd:        ctx.ApplyCmd,
+		DestroyCmd:      ctx.DestroyCmd,
 	}, "", nil
 }
 


### PR DESCRIPTION
## what
* Fix `destroy` command comment

## why
* Comment for `destroy` command was not populated

```
▶️ To apply this plan, comment:
atlantis/testing apply -p terraform
🚮 To destroy this plan, comment:
``
🔁 To plan this project again, comment:
atlantis/testing plan -p terraform
```
