### PR TITLE
Pre-build static assets. Don't build static assets in `.travis.yaml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
 - make deps
-- make dist
+- export CGO_ENABLED=0
 - gox -osarch="windows/386 windows/amd64 freebsd/arm netbsd/386 netbsd/amd64 netbsd/arm linux/s390x linux/arm darwin/386 darwin/amd64 linux/386 linux/amd64 freebsd/amd64 freebsd/386 openbsd/386 openbsd/amd64" -output "release/atlantis_{{.OS}}_{{.Arch}}"
 - ls -l release/
 - make build-service

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,6 @@ debug: ## Output internal make variables
 
 deps: ## Download dependencies
 	go get -u github.com/golang/dep/cmd/dep
-	go get github.com/jteeuwen/go-bindata/...
-	go get github.com/elazarl/go-bindata-assetfs/...
 	dep ensure
 
 build-service: ## Build the main Go service
@@ -63,9 +61,7 @@ test-coverage-html:
 	go tool cover -html .cover/cover.out
 
 dist: ## Package up everything in static/ using go-bindata-assetfs so it can be served by a single binary
-	rm -f server/static/bindata_assetfs.go && \
-	go-bindata-assetfs -o server/static/bindata_assetfs.go -pkg static -prefix server server/static/... && \
-	go fmt server/static/bindata_assetfs.go
+	rm -f server/static/bindata_assetfs.go && go-bindata-assetfs -pkg static -prefix server server/static/... && mv bindata_assetfs.go server/static
 
 release: ## Create packages for a release
 	./scripts/binary-release.sh

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.9.0-cp"
+const atlantisVersion = "0.9.1-cp"
 
 func main() {
 	v := viper.New()

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.9.1-cp"
+const atlantisVersion = "0.9.0-cp.1"
 
 func main() {
 	v := viper.New()

--- a/server/static/bindata_assetfs.go
+++ b/server/static/bindata_assetfs.go
@@ -90,7 +90,7 @@ func staticBindata_assetfsGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/bindata_assetfs.go", size: 0, mode: os.FileMode(420), modTime: time.Unix(1570116691, 0)}
+	info := bindataFileInfo{name: "static/bindata_assetfs.go", size: 0, mode: os.FileMode(420), modTime: time.Unix(1570842721, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -110,7 +110,7 @@ func staticCssCustomCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/css/custom.css", size: 7806, mode: os.FileMode(420), modTime: time.Unix(1570116437, 0)}
+	info := bindataFileInfo{name: "static/css/custom.css", size: 7806, mode: os.FileMode(420), modTime: time.Unix(1570832276, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/vendor/github.com/hashicorp/go-getter/go.mod
+++ b/vendor/github.com/hashicorp/go-getter/go.mod
@@ -20,5 +20,3 @@ require (
 	google.golang.org/api v0.1.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )
-
-go 1.13

--- a/vendor/github.com/lkysow/go-gitlab/go.mod
+++ b/vendor/github.com/lkysow/go-gitlab/go.mod
@@ -7,5 +7,3 @@ require (
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	google.golang.org/appengine v1.3.0 // indirect
 )
-
-go 1.13


### PR DESCRIPTION
## what
* Pre-build static assets. Don't build static assets in `.travis.yaml`

## why
* Something wrong with static asset generation on Travis using `go-bindata` and/or `go-bindata-assetfs`