### PR TITLE
Update `atlantisVersion`

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.9.0-cp.2+2019-10-13T21:00:00+00:00"
+const atlantisVersion = "0.9.0.2+2019-10-14T12:25:00+00:00"
 
 func main() {
 	v := viper.New()


### PR DESCRIPTION
## what
* Update `atlantisVersion`

## why
* To use consistent tagging for releases
